### PR TITLE
No.1 Databaseの準備

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+  postgres-cypher:
+    image: postgres:alpine
+    container_name: postgres-cypher-book-api
+    ports:
+      - "5432:5432"
+    volumes:
+      - db-store:/var/lib/postgresql/data
+    environment:
+      LANG: ja_JP.utf8
+      POSTGRES_USER: cypher
+      POSTGRES_PASSWORD: password
+volumes:
+  db-store:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "5432:5432"
     volumes:
       - db-store:/var/lib/postgresql/data
+      - ./postgres:/docker-entrypoint-initdb.d
     environment:
       LANG: ja_JP.utf8
       POSTGRES_USER: cypher

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -6,7 +6,11 @@ CREATE TABLE IF NOT EXISTS cypher.book(
     author     varchar(100) NOT NULL,
     publisher  varchar(100) NOT NULL,
     price      integer      NOT NULL,
-    created_at timestamp    NOT NULL,
-    updated_at timestamp    NOT NULL,
+    created_at timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (isbn)
 );
+
+INSERT INTO cypher.book VALUES
+('9784798142470', 'Spring徹底入門 Spring FrameworkによるJavaアプリケーション開発', '株式会社NTTデータ', '翔泳社', 4400),
+('9784297118594', 'Kotlinサーバーサイドプログラミング実践開発', '竹端尚人', '技術評論社', 3608);

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,0 +1,12 @@
+CREATE SCHEMA IF NOT EXISTS cypher;
+
+CREATE TABLE IF NOT EXISTS cypher.book(
+    isbn       varchar(13)  NOT NULL,
+    title      varchar(100) NOT NULL,
+    author     varchar(100) NOT NULL,
+    publisher  varchar(100) NOT NULL,
+    price      integer      NOT NULL,
+    created_at timestamp    NOT NULL,
+    updated_at timestamp    NOT NULL,
+    PRIMARY KEY (isbn)
+);


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #1 

## やったこと
<!-- このプルリクで何をしたのか？ -->

- docker-composeでpostgresqlを用意してください
docker-composeを利用します (dockerが難しい場合は模範解答を提供します)
  - https://github.com/nemuki/cypher-book-api/pull/14/commits/d71722e9454e0b630f5f9ec8347133f597017e6e
- 起動時にtable createと初期データをセットしてください
  - https://github.com/nemuki/cypher-book-api/pull/14/commits/d322f83e8da98efec7f631b96116870d5114c56d
  - https://github.com/nemuki/cypher-book-api/pull/14/commits/28142c93927f1aee64a50d4f44b05ada6bd012be

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「なし」でOK）（やらない場合は、いつやるのかを明記する。） -->


## 動作確認
<!-- どのような動作確認を行ったのか？結果はどうか？ -->

初期データ

```sql
CREATE SCHEMA IF NOT EXISTS cypher;

CREATE TABLE IF NOT EXISTS cypher.book(
    isbn       varchar(13)  NOT NULL,
    title      varchar(100) NOT NULL,
    author     varchar(100) NOT NULL,
    publisher  varchar(100) NOT NULL,
    price      integer      NOT NULL,
    created_at timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_at timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
    PRIMARY KEY (isbn)
);

INSERT INTO cypher.book VALUES
('9784798142470', 'Spring徹底入門 Spring FrameworkによるJavaアプリケーション開発', '株式会社NTTデータ', '翔泳社', 4400),
('9784297118594', 'Kotlinサーバーサイドプログラミング実践開発', '竹端尚人', '技術評論社', 3608);
```

動作確認

```sh
~/ghq/github.com/nemuki/cypher-book-api on  no_1 via ☕ v11.0.16 via 🅺 
at 18:20:43 ❯ dc up -d
[+] Running 3/3
 ⠿ Network cypher-book-api_default     Created                                                                                                                                                                                         0.0s
 ⠿ Volume "cypher-book-api_db-store"   Created                                                                                                                                                                                         0.0s
 ⠿ Container postgres-cypher-book-api  Started                                                                                                                                                                                         0.3s

~/ghq/github.com/nemuki/cypher-book-api on  no_1 via ☕ v11.0.16 via 🅺 
at 18:20:53 ❯ psql --host=localhost --username=cypher --port=5432 --dbname=cypher     
Password for user cypher: 
psql (14.5)
Type "help" for help.

cypher=# select * from book;
     isbn      |                             title                             |      author       | publisher  | price |         created_at         |         updated_at         
---------------+---------------------------------------------------------------+-------------------+------------+-------+----------------------------+----------------------------
 9784798142470 | Spring徹底入門 Spring FrameworkによるJavaアプリケーション開発 | 株式会社NTTデータ | 翔泳社     |  4400 | 2022-10-12 09:20:54.119163 | 2022-10-12 09:20:54.119163
 9784297118594 | Kotlinサーバーサイドプログラミング実践開発                    | 竹端尚人          | 技術評論社 |  3608 | 2022-10-12 09:20:54.119163 | 2022-10-12 09:20:54.119163
(2 rows)

```

## 特にレビューしていただきたい点



## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）（あれば。無いなら「なし」でOK）-->
