### PR TITLE
No.7 Database例外ハンドリング

### DIFF
--- a/cypher-book-api-domain/src/main/kotlin/dev/nemuki/cypherbookapi/domain/error/business/DatabaseAccessException.kt
+++ b/cypher-book-api-domain/src/main/kotlin/dev/nemuki/cypherbookapi/domain/error/business/DatabaseAccessException.kt
@@ -1,0 +1,6 @@
+package dev.nemuki.cypherbookapi.domain.error.business
+
+// List, Get 処理が失敗した場合
+class DatabaseAccessException(
+    override val message: String,
+) : BusinessException(message)

--- a/cypher-book-api-infra/src/main/kotlin/dev/nemuki/cypherbookapi/infra/repository/BookRepositoryImpl.kt
+++ b/cypher-book-api-infra/src/main/kotlin/dev/nemuki/cypherbookapi/infra/repository/BookRepositoryImpl.kt
@@ -2,7 +2,7 @@ package dev.nemuki.cypherbookapi.infra.repository
 
 import dev.nemuki.cypherbookapi.application.repository.BookRepository
 import dev.nemuki.cypherbookapi.domain.error.business.DataNotFoundException
-import dev.nemuki.cypherbookapi.domain.error.system.ResourceAccessError
+import dev.nemuki.cypherbookapi.domain.error.business.DatabaseAccessException
 import dev.nemuki.cypherbookapi.infra.entity.Book
 import dev.nemuki.cypherbookapi.infra.mapper.BookMapper
 import org.springframework.dao.DataAccessException
@@ -16,7 +16,7 @@ class BookRepositoryImpl(
         val books = try {
             bookMapper.selectAll()
         } catch (ex: DataAccessException) {
-            throw ResourceAccessError("fetch error", ex)
+            throw DatabaseAccessException("BookRepository#getAllでエラーが発生しました")
         }
 
         return books.toEntities()
@@ -26,7 +26,7 @@ class BookRepositoryImpl(
         val book = try {
             bookMapper.findByIsbn(isbn)
         } catch (ex: DataAccessException) {
-            throw ResourceAccessError("fetch error", ex)
+            throw DatabaseAccessException("BookRepository#getByIsbnでエラーが発生しました")
         } ?: throw DataNotFoundException("No Book found. isbn=${isbn}")
 
         return book.toEntity()

--- a/cypher-book-api-web/src/main/kotlin/dev/nemuki/cypherbookapi/web/advice/ExceptionHandlerAdvice.kt
+++ b/cypher-book-api-web/src/main/kotlin/dev/nemuki/cypherbookapi/web/advice/ExceptionHandlerAdvice.kt
@@ -1,6 +1,7 @@
 package dev.nemuki.cypherbookapi.web.advice
 
 import dev.nemuki.cypherbookapi.domain.error.business.DataNotFoundException
+import dev.nemuki.cypherbookapi.domain.error.business.DatabaseAccessException
 import dev.nemuki.cypherbookapi.domain.error.business.InvalidIsbnException
 import dev.nemuki.cypherbookapi.domain.error.system.ResourceAccessError
 import dev.nemuki.cypherbookapi.web.entity.ErrorResponse
@@ -15,6 +16,10 @@ class ExceptionHandlerAdvice {
     @ExceptionHandler(ResourceAccessError::class)
     @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
     fun handleDataAccessException() = ErrorResponse("Failed to access database")
+
+    @ExceptionHandler(DatabaseAccessException::class)
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    fun handleDatabaseAccessException(ex: DatabaseAccessException) = ErrorResponse(ex.message)
 
     @ExceptionHandler(ConstraintViolationException::class)
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
## Issueへのリンク
<!-- resolve: #Issue番号 -->
resolve: #7

## やったこと
<!-- このプルリクで何をしたのか？ -->
- DatabaseAccessException の実装
  - #2 5. Database接続等の例外が発生した場合は HTTP Status 500でJsonを返却してください の処理を変更した形になります
  - 接続の例外とGet、List処理の例外を分けてとる方法がわからずいます

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「なし」でOK）（やらない場合は、いつやるのかを明記する。） -->


## 動作確認
<!-- どのような動作確認を行ったのか？結果はどうか？ -->

### BookRepository#getAll

```
http://localhost:8080/books

HTTP/1.1 500 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Tue, 01 Nov 2022 01:38:37 GMT
Connection: close
Proxy-Connection: close

{
  "reason": "BookRepository#getAllでエラーが発生しました"
}
```

### BookRepository#getByIsbn

```
http://localhost:8080/books/9784798142470

HTTP/1.1 500 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Tue, 01 Nov 2022 01:40:22 GMT
Connection: close
Proxy-Connection: close

{
  "reason": "BookRepository#getByIsbnでエラーが発生しました"
}
```

## 特にレビューしていただきたい点



## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）（あれば。無いなら「なし」でOK）-->
